### PR TITLE
TRIVIAL: remove reference to deprecated template

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -21,7 +21,6 @@
   <meta http-equiv="refresh" content="0;URL='{{ .Page.Params.redirect }}'" /> 
 {{ end }}
 {{- template "_internal/opengraph.html" . -}}
-{{- template "_internal/google_news.html" . -}}
 {{- template "_internal/schema.html" . -}}
 {{- template "_internal/twitter_cards.html" . -}}
 


### PR DESCRIPTION
_internal/google_news.html was deprecated and removed from Hugo in 0.111. Using newer hugo throws error.